### PR TITLE
Update Dockerfile.demo_vitis_ai

### DIFF
--- a/docker/Dockerfile.demo_vitis_ai
+++ b/docker/Dockerfile.demo_vitis_ai
@@ -68,7 +68,7 @@ RUN git clone --recursive https://github.com/anilmartha/incubator-tvm.git --bran
     cmake .. && \
     make -j$(nproc) && \
     cd ../python/ && \
-    sudo -H python3 -m pip install --install-option="--install-scripts=/usr/local/bin"
+    sudo -H python3 -m pip install --install-option="--install-scripts=/usr/local/bin" tvm
 
 ENV USER="root"
 ENTRYPOINT ["/etc/login.sh"]


### PR DESCRIPTION
fix build error of tvm  docker 
error message :10:38:37  [100%] Linking CXX shared library libtvm.so
10:38:37  [100%] Built target tvm
10:38:37  
10:38:37  The command '/opt/vitis_ai/conda/bin/conda run -n vitis-ai-tensorflow /bin/bash -c git clone --recursive https://github.com/anilmartha/incubator-tvm.git --branch vitis-ai-integration &&     mkdir -p incubator-tvm/build && 	source /opt/xilinx/xrt/setup.sh &&     cp incubator-tvm/cmake/config.cmake incubator-tvm/build/ &&     cd incubator-tvm/build/ &&     echo set\(USE_LLVM ON\) >> config.cmake &&     echo set\(USE_VITIS_AI ON\) >> config.cmake &&     cmake .. &&     make -j$(nproc) &&     cd ../python/ &&     sudo -H python3 -m pip install --install-option="--install-scripts=/usr/local/bin"' returned a non-zero code: 1

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
